### PR TITLE
Feat/default scope for delete date column

### DIFF
--- a/src/persistence/SubjectDatabaseEntityLoader.ts
+++ b/src/persistence/SubjectDatabaseEntityLoader.ts
@@ -84,7 +84,8 @@ export class SubjectDatabaseEntityLoader {
                 loadRelationIds: {
                     relations: loadRelationPropertyPaths,
                     disableMixedMap: true
-                }
+                },
+                scope: false
             };
 
             // load database entities for all given ids

--- a/test/functional/query-builder/scope/entity/PostWithoutScope.ts
+++ b/test/functional/query-builder/scope/entity/PostWithoutScope.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {DeleteDateColumn} from "../../../../../src/decorator/columns/DeleteDateColumn";
+
+@Entity()
+export class PostWithoutScope {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @DeleteDateColumn()
+    deletedAt: Date;
+
+}

--- a/test/functional/query-builder/scope/query-builder-scope.ts
+++ b/test/functional/query-builder/scope/query-builder-scope.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Connection} from "../../../../src/connection/Connection";
 import {Post} from "./entity/Post";
+import {PostWithoutScope} from "./entity/PostWithoutScope";
 
 describe("query builder > query scope", () => {
 
@@ -11,6 +12,40 @@ describe("query builder > query scope", () => {
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
+
+    it("the default scope should be non-deleted when the default scope is undefined and the @DeleteDateColumn is set", () => Promise.all(connections.map(async connection => {
+
+        const post1 = new PostWithoutScope();
+        post1.title = "title#1";
+        const post2 = new PostWithoutScope();
+        post2.title = "title#2";
+        const post3 = new PostWithoutScope();
+        post3.title = "title#3";
+
+        await connection.manager.save(post1);
+        await connection.manager.save(post2);
+        await connection.manager.save(post3);
+
+        await connection.manager.softRemove(post1);
+
+        const loadedWithDefaultScopePosts = await connection
+            .createQueryBuilder()
+            .select("post")
+            .from(PostWithoutScope, "post")
+            .getMany();
+
+        loadedWithDefaultScopePosts!.length.should.be.equal(2);
+        loadedWithDefaultScopePosts![0].title.should.be.equals("title#2");
+        loadedWithDefaultScopePosts![1].title.should.be.equals("title#3");
+
+        const loadedWithDefaultScopePost = await connection
+            .createQueryBuilder()
+            .select("post")
+            .from(PostWithoutScope, "post")
+            .getOne();
+        loadedWithDefaultScopePost!.title.should.be.equals("title#2");
+
+    })));
 
     it("should set defalut query scope correctly", () => Promise.all(connections.map(async connection => {
 

--- a/test/functional/query-builder/soft-delete/query-builder-soft-delete.ts
+++ b/test/functional/query-builder/soft-delete/query-builder-soft-delete.ts
@@ -32,7 +32,7 @@ describe("query builder > soft-delete", () => {
             .where("name = :name", { name: "Alex Messer" })
             .execute();
 
-        const loadedUser1 = await connection.getRepository(User).findOne({ name: "Alex Messer" });
+        const loadedUser1 = await connection.getRepository(User).findOne({ name: "Alex Messer" }, { scope: false });
         expect(loadedUser1).to.exist;
         expect(loadedUser1!.deletedAt).to.be.instanceof(Date);
 
@@ -43,7 +43,7 @@ describe("query builder > soft-delete", () => {
             .where("name = :name", { name: "Alex Messer" })
             .execute();
 
-        const loadedUser2 = await connection.getRepository(User).findOne({ name: "Alex Messer" });
+        const loadedUser2 = await connection.getRepository(User).findOne({ name: "Alex Messer" }, { scope: false });
         expect(loadedUser2).to.exist;
         expect(loadedUser2!.deletedAt).to.be.equals(null);
 
@@ -69,7 +69,10 @@ describe("query builder > soft-delete", () => {
             .limit(limitNum)
             .execute();
 
-            const loadedUsers = await connection.getRepository(User).find({deletedAt: Not(IsNull())});
+            const loadedUsers = await connection.getRepository(User).find({
+                 where: { deletedAt: Not(IsNull()) },
+                 scope: false
+            });
             expect(loadedUsers).to.exist;
             loadedUsers!.length.should.be.equal(limitNum);
         } else {
@@ -107,7 +110,10 @@ describe("query builder > soft-delete", () => {
             .from(User)
             .execute();
 
-            const loadedUsers = await connection.getRepository(User).find({deletedAt: IsNull()});
+            const loadedUsers = await connection.getRepository(User).find({
+                 where: { deletedAt: Not(IsNull()) },
+                 scope: false
+            });
             expect(loadedUsers).to.exist;
             loadedUsers!.length.should.be.equal(limitNum);
         } else {

--- a/test/functional/repository/find-options-scope/entity/PostWithoutScope.ts
+++ b/test/functional/repository/find-options-scope/entity/PostWithoutScope.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {DeleteDateColumn} from "../../../../../src/decorator/columns/DeleteDateColumn";
+
+@Entity()
+export class PostWithoutScope {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @DeleteDateColumn()
+    deletedAt: Date;
+
+}

--- a/test/functional/repository/soft-delete/repository-soft-delete.ts
+++ b/test/functional/repository/soft-delete/repository-soft-delete.ts
@@ -34,7 +34,9 @@ describe("repository > soft-delete", () => {
         await postRepository.softDelete({ id: 1, name: "post#1" });
 
         // load to check
-        const loadedPosts = await postRepository.find();
+        const loadedPosts = await postRepository.find({
+            scope: false
+        });
 
         // assert
         loadedPosts.length.should.be.equal(2);
@@ -51,7 +53,9 @@ describe("repository > soft-delete", () => {
         // restore one
         await postRepository.restore({ id: 1, name: "post#1" });
         // load to check
-        const restoredPosts = await postRepository.find();
+        const restoredPosts = await postRepository.find({
+            scope: false
+        });
 
         // assert
         restoredPosts.length.should.be.equal(2);

--- a/test/functional/repository/soft-delete/repository-soft-remove.ts
+++ b/test/functional/repository/soft-delete/repository-soft-remove.ts
@@ -36,7 +36,9 @@ describe("repository > soft-remove", () => {
         await postRepository.softRemove(newPost1);
 
         // load to check
-        const loadedPosts = await postRepository.find();
+        const loadedPosts = await postRepository.find({
+            scope: false
+        });
 
         // assert
         loadedPosts.length.should.be.equal(2);
@@ -53,7 +55,9 @@ describe("repository > soft-remove", () => {
         // recover one
         await postRepository.recover(loadedPost1!);
         // load to check
-        const recoveredPosts = await postRepository.find();
+        const recoveredPosts = await postRepository.find({
+            scope: false
+        });
 
         // assert
         recoveredPosts.length.should.be.equal(2);


### PR DESCRIPTION
1. added default scope for delete date column
2. fixed set scope to false when loading database entities for all given ids in the SubjectDatabaseEntityLoader
3. updated test for the default scope for delete date column